### PR TITLE
member,  LibraryInventory, SecurityConfiguration 코드 추가 및 redis, Library 리펙터링 코드 추가

### DIFF
--- a/src/main/java/server/book_library/config/redis/config/RedisConfig.java
+++ b/src/main/java/server/book_library/config/redis/config/RedisConfig.java
@@ -44,6 +44,7 @@ public class RedisConfig {
     public RedisConnectionFactory redisConnectionFactory() {
         LettuceConnectionFactory factory = new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
         factory.afterPropertiesSet();
+        factory.getConnection().flushAll();
         return factory;
     }
 

--- a/src/main/java/server/book_library/config/security/auths/dto/LoginDto.java
+++ b/src/main/java/server/book_library/config/security/auths/dto/LoginDto.java
@@ -4,15 +4,8 @@ import lombok.Getter;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
-
-public class AuthDto {
-
-    @Getter
-    public class Login {
-        @Email
-        @NotBlank(message = "이메일을 확인해주세요")
+@Getter
+public class LoginDto {
         private String email;
-        @NotBlank(message = "비밀번호를 확인해주세요")
         private String password;
-    }
 }

--- a/src/main/java/server/book_library/config/security/auths/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/server/book_library/config/security/auths/filter/JwtAuthenticationFilter.java
@@ -9,7 +9,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import server.book_library.domain.member.entity.Member;
-import server.book_library.config.security.auths.dto.AuthDto;
+import server.book_library.config.security.auths.dto.LoginDto;
 import server.book_library.config.security.auths.jwt.JwtTokenizer;
 
 import javax.servlet.FilterChain;
@@ -31,7 +31,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response){
         ObjectMapper objectMapper = new ObjectMapper();
-        AuthDto.Login loginDto = objectMapper.readValue(request.getInputStream(), AuthDto.Login.class);
+        LoginDto loginDto = objectMapper.readValue(request.getInputStream(), LoginDto.class);
 
         UsernamePasswordAuthenticationToken authenticationToken =
                 new UsernamePasswordAuthenticationToken(loginDto.getEmail(),loginDto.getPassword());

--- a/src/main/java/server/book_library/config/security/auths/utils/CustomAuthorityUtils.java
+++ b/src/main/java/server/book_library/config/security/auths/utils/CustomAuthorityUtils.java
@@ -18,7 +18,7 @@ public class CustomAuthorityUtils {
 
     public List<GrantedAuthority> createdAuthorities(List<String> roles){
         return roles.stream()
-                .map(role -> new SimpleGrantedAuthority("ROLE" + role))
+                .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/server/book_library/config/security/config/SecurityConfiguration.java
+++ b/src/main/java/server/book_library/config/security/config/SecurityConfiguration.java
@@ -43,18 +43,18 @@ public class SecurityConfiguration {
                 .formLogin().disable()
                 .httpBasic().disable()
                 .apply(new CustomFilterConfigurer())
-                .and();
-//                .authorizeRequests(authorize -> authorize
-//                        .antMatchers(HttpMethod.GET, "/books/**").permitAll()
-//                        .antMatchers( "/books/**").hasRole("ADMIN")
-//                        .antMatchers(HttpMethod.GET, "/libraries/**").permitAll()
-//                        .antMatchers( "/libraries/**").hasRole("ADMIN")
-//                        .antMatchers("/libraries/inventories/**").hasRole("ADMIN")
-//                        .antMatchers("/loan/**").hasRole("USER")
-//                        .antMatchers("/return/**").hasRole("USER")
-//                        .antMatchers(HttpMethod.DELETE,"/members/**").hasRole("USER")
-//                        .antMatchers( "/members/**").permitAll()
-//                        .anyRequest().permitAll());
+                .and()
+                .authorizeRequests(authorize -> authorize
+                        .antMatchers(HttpMethod.GET, "/books/**").permitAll()
+                        .antMatchers( "/books/**").hasRole("ADMIN")
+                        .antMatchers(HttpMethod.GET, "/libraries/**").permitAll()
+                        .antMatchers( "/libraries/**").hasRole("ADMIN")
+                        .antMatchers("/libraries/inventories/**").hasRole("ADMIN")
+                        .antMatchers("/loan/**").hasRole("USER")
+                        .antMatchers("/return/**").hasRole("USER")
+                        .antMatchers(HttpMethod.DELETE,"/members/**").hasRole("USER")
+                        .antMatchers( "/members/**").permitAll()
+                        .anyRequest().permitAll());
         return http.build();
     }
 

--- a/src/main/java/server/book_library/domain/book/controller/BookController.java
+++ b/src/main/java/server/book_library/domain/book/controller/BookController.java
@@ -43,7 +43,7 @@ public class BookController {
 
     @GetMapping("/{book-id}")
     public ResponseEntity<?> getBook(@PathVariable("book-id") long bookId){
-        Book book = bookService.findById(bookId);
+        Book book = bookService.findBook(bookId);
         BookDto.DetailResponse response = bookMapper.bookToBookDetailResponse(book);
 
         return new ResponseEntity<>(new SingleResponse<>(response), HttpStatus.OK);

--- a/src/main/java/server/book_library/domain/book/entity/Book.java
+++ b/src/main/java/server/book_library/domain/book/entity/Book.java
@@ -10,6 +10,7 @@ import server.book_library.util.BaseEntity;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -22,5 +23,5 @@ public class Book extends BaseEntity {
 
     @OneToMany(mappedBy = "book", cascade = CascadeType.REMOVE)
     @JsonIgnoreProperties("book")
-    private List<LibraryInventory> libraryInventories;
+    private List<LibraryInventory> libraryInventories = new ArrayList<>();
 }

--- a/src/main/java/server/book_library/domain/book/service/BookService.java
+++ b/src/main/java/server/book_library/domain/book/service/BookService.java
@@ -34,6 +34,10 @@ public class BookService {
         return bookRepository.save(findBook);
     }
 
+    public Book findBook(long bookId) {
+        return findById(bookId);
+    }
+
     public Page<Book> findAllBooks(int page, int size) {
         return bookRepository.findByIsDeletedFalse(PageRequest.of(page, size));
     }
@@ -52,7 +56,6 @@ public class BookService {
         return book;
     }
 
-    @Cacheable(value = "book", key = "#id", unless = "#result == null", cacheManager = "cacheManagerTest")
     public Book findBookById(long id) {
         return bookRepository.findById(id)
                 .orElseThrow(() -> new BusinessLogicException(ExceptionCode.BOOK_NOT_FOUND));

--- a/src/main/java/server/book_library/domain/library/inventory/controller/LibraryInventoryController.java
+++ b/src/main/java/server/book_library/domain/library/inventory/controller/LibraryInventoryController.java
@@ -32,7 +32,7 @@ public class LibraryInventoryController {
 
         libraryInventory.setLibrary(library);
         libraryInventory.setBook(book);
-        LibraryInventory registration = libraryInventoryService.registrationInLibrary(libraryInventory);
+        LibraryInventory registration = libraryInventoryService.createLibraryInventory(libraryInventory);
 
         LibraryInventoryDto.Response response = libraryInventoryMapper.LibraryInventoryToLibraryInventoryResponse(registration);
         return new ResponseEntity<>(new SingleResponse<>(response), HttpStatus.CREATED);
@@ -44,8 +44,8 @@ public class LibraryInventoryController {
                                                     @RequestBody LibraryInventoryDto.Patch patch) {
         LibraryInventory libraryInventory = libraryInventoryMapper.LibraryInventoryPatchToLibraryInventory(patch);
         libraryInventory.setId(libraryInventoryId);
-        LibraryInventory updatelibraryInventory = libraryInventoryService.updateLibraryInventory(libraryInventory);
-        LibraryInventoryDto.Response response = libraryInventoryMapper.LibraryInventoryToLibraryInventoryResponse(updatelibraryInventory);
+        LibraryInventory updateLibraryInventory = libraryInventoryService.updateLibraryInventory(libraryInventory);
+        LibraryInventoryDto.Response response = libraryInventoryMapper.LibraryInventoryToLibraryInventoryResponse(updateLibraryInventory);
 
         return new ResponseEntity<>(new SingleResponse<>(response), HttpStatus.OK);
     }

--- a/src/main/java/server/book_library/domain/library/inventory/dto/LibraryInventoryDto.java
+++ b/src/main/java/server/book_library/domain/library/inventory/dto/LibraryInventoryDto.java
@@ -18,11 +18,12 @@ public class LibraryInventoryDto {
     }
 
     @Getter
-    @AllArgsConstructor
+    @NoArgsConstructor
     public static class Patch{
         private int totalQuantity;
     }
-    @Getter
+
+    @Getter @Setter
     @AllArgsConstructor
     @NoArgsConstructor
     public static class Response{

--- a/src/main/java/server/book_library/domain/library/inventory/entity/LibraryInventory.java
+++ b/src/main/java/server/book_library/domain/library/inventory/entity/LibraryInventory.java
@@ -12,6 +12,7 @@ import server.book_library.domain.loan.entity.Loan;
 import server.book_library.util.BaseEntity;
 
 import javax.persistence.*;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -38,7 +39,7 @@ public class LibraryInventory extends BaseEntity {
 
     @OneToMany(mappedBy = "libraryInventory", cascade = CascadeType.REMOVE)
     @JsonManagedReference(value = "loan_libraryInventory")
-    private List<Loan> loans;
+    private List<Loan> loans = new ArrayList<>();
 
     public enum LoanStatus{
         대여가능, 모두대여중

--- a/src/main/java/server/book_library/domain/library/library/controller/LibraryController.java
+++ b/src/main/java/server/book_library/domain/library/library/controller/LibraryController.java
@@ -1,6 +1,7 @@
 package server.book_library.domain.library.library.controller;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +21,7 @@ import java.util.List;
 public class LibraryController {
     private final LibraryService libraryService;
     private final LibraryMapper libraryMapper;
-    
+
     @PostMapping
     public ResponseEntity<?> addLibrary(@RequestBody LibraryDto.Post post) {
         Library library = libraryMapper.libraryPostToLibrary(post);
@@ -52,7 +53,7 @@ public class LibraryController {
     @GetMapping
     public ResponseEntity<?> getsLibraries(@RequestParam int page,
                                            @RequestParam int size) {
-        Page<Library> librariesPages = libraryService.getLibraries(page, size);
+        Page<Library> librariesPages = libraryService.getLibraries(page - 1, size);
         List<Library> libraries = librariesPages.getContent();
         List<LibraryDto.Response> responses = libraryMapper.librariesToLibraryResponses(libraries);
 

--- a/src/main/java/server/book_library/domain/library/library/entity/Library.java
+++ b/src/main/java/server/book_library/domain/library/library/entity/Library.java
@@ -1,6 +1,5 @@
 package server.book_library.domain.library.library.entity;
 
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Getter;
 import lombok.Setter;
 import server.book_library.domain.library.inventory.entity.LibraryInventory;
@@ -9,6 +8,7 @@ import server.book_library.util.BaseEntity;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -19,5 +19,5 @@ public class Library extends BaseEntity {
     private String location;
 
     @OneToMany(mappedBy = "library", cascade = CascadeType.REMOVE)
-    private List<LibraryInventory> libraryInventories;
+    private List<LibraryInventory> libraryInventories = new ArrayList<>();
 }

--- a/src/main/java/server/book_library/domain/library/library/service/LibraryService.java
+++ b/src/main/java/server/book_library/domain/library/library/service/LibraryService.java
@@ -1,9 +1,14 @@
 package server.book_library.domain.library.library.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -13,28 +18,39 @@ import server.book_library.domain.library.library.repository.LibraryRepository;
 import server.book_library.global.exception.BusinessLogicException;
 import server.book_library.global.exception.ExceptionCode;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class LibraryService {
     private final LibraryRepository libraryRepository;
+    private final CacheManager cacheManager;
 
     @CachePut(value = "library", key = "#result.id", unless = "#result == null", cacheManager = "cacheManagerTest")
     public Library createLibrary(Library library) {
         Library save = libraryRepository.save(library);
-        save.setLibraryInventories(null);
+        save.setLibraryInventories(new ArrayList<>());
         return save;
     }
 
     @CachePut(value = "library", key = "#result.id", unless = "#result == null", cacheManager = "cacheManagerTest")
     public Library updateLibrary(Library library) {
         Library findLibrary = findById(library.getId());
-        Optional.ofNullable(findLibrary.getName()).ifPresent(findLibrary::setName);
-        Optional.ofNullable(findLibrary.getLocation()).ifPresent(findLibrary::setLocation);
+        Optional.ofNullable(library.getName()).ifPresent(findLibrary::setName);
+        Optional.ofNullable(library.getLocation()).ifPresent(findLibrary::setLocation);
 
-        return libraryRepository.save(findLibrary);
+        Library updatedLibrary = libraryRepository.save(findLibrary);
+
+        List<LibraryInventory> libraryInventories = new ArrayList<>(findLibrary.getLibraryInventories());
+
+        for(LibraryInventory libraryInventory: libraryInventories) {
+            libraryInventory.setBook(libraryInventory.getBook());
+        }
+        updatedLibrary.setLibraryInventories(libraryInventories);
+        return updatedLibrary;
     }
 
     @Cacheable(value = "libraries", key = "#page + '-' + #size", cacheManager = "cacheManagerTest")
@@ -46,13 +62,16 @@ public class LibraryService {
 
     // library::1 -> 내용 Json
     // library::2 -> 내용 Json
-    @CacheEvict(value = "library", key = "#result.id")
-    public Library deleteLibrary(Library library){
+    @CacheEvict(value = "library", key = "#library.id")
+    public Library deleteLibrary(Library library) {
         library.setDeleted(true);
         List<LibraryInventory> libraryInventories = library.getLibraryInventories();
-        for(LibraryInventory libraryInventory : libraryInventories) {
-            libraryInventory.setDeleted(true);
+        if(libraryInventories != null) {
+            for (LibraryInventory libraryInventory : libraryInventories) {
+                libraryInventory.setDeleted(true);
+            }
         }
+        evictAllLibraries();
         return libraryRepository.save(library);
     }
 
@@ -61,9 +80,23 @@ public class LibraryService {
         Optional<Library> optionalLibrary = libraryRepository.findById(id);
         Library library = optionalLibrary.orElseThrow(() -> new BusinessLogicException(ExceptionCode.LIBRARY_NOT_FOUND));
 
+        List<LibraryInventory> libraryInventories = new ArrayList<>(library.getLibraryInventories());
+
+        for(LibraryInventory libraryInventory: libraryInventories) {
+            libraryInventory.setBook(libraryInventory.getBook());
+        }
+        library.setLibraryInventories(libraryInventories);
+
         if(library.isDeleted()) {
             throw new BusinessLogicException(ExceptionCode.LIBRARY_IS_GONE);
         }
         else return library;
+    }
+
+    public void evictAllLibraries() {
+        Cache cache = cacheManager.getCache("libraries");
+        if (cache != null) {
+            cache.clear();
+        }
     }
 }

--- a/src/main/java/server/book_library/domain/member/service/MemberService.java
+++ b/src/main/java/server/book_library/domain/member/service/MemberService.java
@@ -27,6 +27,13 @@ public class MemberService {
     private long maxLoanQuantity;
 
     public Member createMember(Member member) {
+        String email = member.getEmail();
+
+        boolean exists = isMemberExists(email);
+        if (exists) {
+            throw new BusinessLogicException(ExceptionCode.MEMBER_EXISTS);
+        }
+
         String encodedPassword = passwordEncoder.encode(member.getPassword());
         log.info("Encrypted password: {}", encodedPassword);
         member.setPassword(encodedPassword);
@@ -52,11 +59,11 @@ public class MemberService {
         return optionalMember.orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
     }
 
-    public Member findVerifiedEmail(String email) {
-        Optional<Member> findMember = memberRepository.findByEmail(email);
-        return findMember.orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
-    }
+    public boolean isMemberExists(String email) {
+        Optional<Member> member = memberRepository.findByEmail(email);
 
+        return member.isPresent();
+    }
 
     public void validLoanQuantity(Member member) {
         //Todo: 사용자가 대여가능한 상태인지 확인

--- a/src/main/java/server/book_library/global/exception/ExceptionCode.java
+++ b/src/main/java/server/book_library/global/exception/ExceptionCode.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 public enum ExceptionCode {
     MEMBER_NOT_FOUND(404, "회원의 ID를 찾을 수 없습니다."),
     BOOK_NOT_FOUND(404, "책을 찾을 수 없습니다."),
+    BOOK_HAS_DELETE(404, "삭제된 책입니다."),
     LIBRARY_NOT_FOUND(404, "도서관을 찾을 수 없습니다."),
     LIBRARY_INVENTORY_OUT_OF_STOCK(404,"도서 재고가 없습니다."),
     LOAN_NOT_FOUND(404,"대여 ID를 찾을 수 없습니다"),
@@ -22,7 +23,8 @@ public enum ExceptionCode {
     QUANTITY_UPDATE_IMPOSSIBLE(403,"대여중인 책이 변경 수량보다 많습니다"),
     LIBRARY_INVENTORY_ALREADY_EXISTS(403,"도서관에 이미 등록된 책입니다."),
     UNABLE_MEMBER_ACCOUNT_WITHDRAWAL(403,"대여중인 책이 있어서 탈퇴가 불가능 합니다."),
-    NOT_LOGIN(402, "로그인 할수 업습니다. 다시 한번 확인해주세요");
+    NOT_LOGIN(402, "로그인 할수 업습니다. 다시 한번 확인해주세요"),
+    MEMBER_EXISTS(409, "이미 등록이 되어있는 회원입니다.");
 
     @Getter
     private final int status;

--- a/src/main/java/server/book_library/util/BaseEntity.java
+++ b/src/main/java/server/book_library/util/BaseEntity.java
@@ -1,5 +1,6 @@
 package server.book_library.util;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
@@ -17,9 +18,15 @@ public abstract class BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @CreatedDate
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
+
     @LastModifiedDate
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime updatedAt;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime deletedAt;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
     password: ENC(B4pEKuqnz7tW3mgIqDR5Tmj/1W1eeVoA)
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
feat : 
1. Application을 실행 시켰을 때, Cache에 시간이 일렬로 나와
   pattern = "yyyy-MM-dd HH:mm:ss" 코드 추가

2. SecurityConfiguration에 권한별로 조회 및 삭제등을 나누는 코드 추가

3. member 생성 시, email을 조회하여 멤버가 존재하면 ExceptionCode를 발생시키도록 코드 추가

4. libraryInventory 책 삭제확인 코드 추가 및 Exception코드 발생

refactor : 
1. Library를 생성, 조회, 삭제, 조회 순으로 진행했을 때, Cache에 삭제된 Library가 남아있는 문제 해결 코드 추가

2. 애플리케이션을 종료하고 재실행 시켜 조회를 하면 남아있는 캐시로 인해 재 조회시, 중복 발생 -> Bean이 실행되면 전체 삭제하도록 변경
